### PR TITLE
Implement threadsafe functions, promise state, SharedArrayBuffer, and property filtering

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -199,14 +199,6 @@ list(APPEND skipped_tests
   get-error-location
 
   # Not implemented
-  call-threadsafe-function-after-release
-  call-threadsafe-function-with-data
-  create-threadsafe-function
-  create-threadsafe-function-with-callback
-  create-threadsafe-function-with-context
-  create-threadsafe-function-with-finalizer
-
-  # Not implemented
   call-function-in-context
   run-script-in-context
 
@@ -219,12 +211,6 @@ list(APPEND skipped_tests
   # https://bugs.webkit.org/show_bug.cgi?id=250554
   atomics-wait-timeout
   atomics-wait-timeout-notify
-  create-promise-reject
-  create-promise-resolve
-
-  # https://bugs.webkit.org/show_bug.cgi?id=257709
-  create-sharedarraybuffer
-  create-sharedarraybuffer-with-backing-store
 
   # https://bugs.webkit.org/show_bug.cgi?id=261600
   create-module-import-missing


### PR DESCRIPTION
Implements previously stubbed engine functions:

- **Threadsafe functions** — queue-based implementation using `uv_async_t` and atomics for cross-thread signaling
- **Promise state/result** — tracks state via non-enumerable properties (`JSObjectSetPrivateProperty` silently fails on promise objects in JSC)
- **SharedArrayBuffer** — delegates to ArrayBuffer implementations since JSC uses the same underlying API, with `js_create_sharedarraybuffer` using `calloc` for zero-initialized memory
- **Property name filtering** — `js_get_filtered_property_names` with index skip support via `JSObjectCopyPropertyNames`
- **BigInt word stubs** — `js_create_bigint_words` / `js_get_value_bigint_words` (linker symbols only, no JSC C API available)

Enables 10 previously skipped tests (6 threadsafe, 2 promise, 2 SharedArrayBuffer). 128/128 tests pass.